### PR TITLE
Fixed non-sequential position params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+./lib/
 lib64/
 parts/
 sdist/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 0.0.2
+
+- Made position parameters sequential

--- a/actions/elbow_torque.yaml
+++ b/actions/elbow_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/actions/grip_torque.yaml
+++ b/actions/grip_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/actions/hand_torque.yaml
+++ b/actions/hand_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/actions/pivot_torque.yaml
+++ b/actions/pivot_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/actions/shoulder_torque.yaml
+++ b/actions/shoulder_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/actions/wrist_torque.yaml
+++ b/actions/wrist_torque.yaml
@@ -15,4 +15,4 @@ parameters:
     type: "boolean"
     description: "Set or get torque?"
     default: false
-    position: 2
+    position: 1

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: robotpack
 description: Pack for controlling a PhantomX Reactor
-version: 0.0.1
+version: 0.0.2
 author: Matthew Stone
 email: matthew99@gmail.com


### PR DESCRIPTION
Some of the `position` params were non-sequential. Recent versions of ST2 will barf at this with messages like:

```
...
requests.exceptions.HTTPError: 400 Client Error: Bad Request
MESSAGE: Failed to register action "/opt/stackstorm/packs/robotpack/actions/elbow_torque.yaml" from pack "robotpack": Positions supplied [0, 2] for parameters are not contiguous. for url: http://0.0.0.0:9101/v1/packs/register

traceback: None
```